### PR TITLE
Change role variables so they are prefixed with avahi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Ansible Playbook for [avahi](http://avahi.org/) the zeroconf software.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 ```
-hostname: "{{ ansible_hostname }}"
-domain: "local"
-useipv4: "yes"
-useipv6: "no"
+avahi_hostname: "{{ ansible_hostname }}"
+avahi_domain: "local"
+avahi_useipv4: "yes"
+avahi_useipv6: "no"
 ```
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-hostname: "{{ ansible_hostname }}"
-domain: "local"
-useipv4: "yes"
-useipv6: "no"
+avahi_hostname: "{{ ansible_hostname }}"
+avahi_domain: "local"
+avahi_useipv4: "yes"
+avahi_useipv6: "no"

--- a/templates/avahi-daemon.conf.j2
+++ b/templates/avahi-daemon.conf.j2
@@ -22,11 +22,11 @@
 # file!
 
 [server]
-host-name={{hostname}}
-domain-name={{domain}}
+host-name={{avahi_hostname}}
+domain-name={{avahi_domain}}
 #browse-domains=0pointer.de, zeroconf.org
-use-ipv4={{useipv4}}
-use-ipv6={{useipv6}}
+use-ipv4={{avahi_useipv4}}
+use-ipv6={{avahi_useipv6}}
 #allow-interfaces=eth0
 #deny-interfaces=eth1
 #check-response-ttl=no


### PR DESCRIPTION
At the moment the role will conflict easily with anything using the variables
it contains, this puts the variables in their own namespace to help mitigate
that possibility.
