### PR TITLE
DEPRECATION WARNING -- Instead of sudo/sudo_user, use become/become_u…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,21 @@ before_install:
   - tests/ci.sh
 install:
   # Install Ansible.
-  - pip install ansible==1.8.0
+  - pip install ansible==2.1.2.0
+  # Check ansible version
+  - ansible --version
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
 script:
   # Check the role/playbook's syntax.
   - ansible-playbook --syntax-check --inventory-file=tests/inventory tests/test.yml
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook --inventory-file=tests/inventory tests/test.yml --connection=local --sudo
+  - ansible-playbook --inventory-file=tests/inventory tests/test.yml --connection=local
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook --inventory-file=tests/inventory tests/test.yml --connection=local --sudo
+    ansible-playbook --inventory-file=tests/inventory tests/test.yml --connection=local
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,4 @@
 
 - name: restart avahi-daemon
   service: name=avahi-daemon state=restarted
-  sudo: yes
+  become: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,9 +1,5 @@
 ---
-
-- hosts: all
-  vars_files:
-    - '../defaults/main.yml'
-  tasks:
-    - include: '../tasks/main.yml'
-  handlers:
-    - include: '../handlers/main.yml'
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible-avahi


### PR DESCRIPTION
`sudo` has now been depreciated and will be removed in a future release.

`become` is the replacement and `become_method` defaults to `sudo`