### PR TITLE
Add support for installing avahi utils package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ hostname: "{{ ansible_hostname }}"
 domain: "local"
 useipv4: "yes"
 useipv6: "no"
+avahi_install_utils: false
 ```
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ hostname: "{{ ansible_hostname }}"
 domain: "local"
 useipv4: "yes"
 useipv6: "no"
+avahi_install_utils: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,10 @@
 - name: Install avahi-daemon package
   apt: pkg=avahi-daemon state=present
 
+- name: Install avahi-utils package
+  when: avahi_install_utils
+  apt: pkg=avahi-daemon state=present
+
 - name: Avahi | Update avahi config
   template:
     src: avahi-daemon.conf.j2
@@ -12,3 +16,4 @@
     mode: 0644
   notify:
     - restart avahi-daemon
+


### PR DESCRIPTION
Being able to install the utils package seems like useful functionality in the
role but to preseve the existing behaviour the default is not installing it.
This could be trivially changed in defaults/main.yml should it be desired.